### PR TITLE
Studio icons: correct URLs; App prebuild Dieter; post-build guard

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -2,10 +2,12 @@
   "name": "@ck/app",
   "private": true,
   "scripts": {
+    "prebuild": "pnpm --filter @ck/dieter build && node ../../scripts/copy-dieter-assets.js",
     "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start -p 3001",
-    "postinstall": "echo 'no symlink; copy-on-build per ADR-005'"
+    "postinstall": "echo 'no symlink; copy-on-build per ADR-005'",
+    "postbuild": "node ../../tools/ci/assert-dieter-icon-present.cjs"
   },
   "dependencies": {
     "@supabase/ssr": "^0.7.0",

--- a/apps/app/public/studio/index.html
+++ b/apps/app/public/studio/index.html
@@ -21,10 +21,10 @@
     <main class="studio-grid" data-left="open" data-right="open" role="main">
       <aside class="panel panel--left" aria-label="Left Panel">
         <div class="panel__header">
-          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/folder-16.svg" alt="" /></span>
+          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/folder-16.svg" alt="" /></span>
           <span class="panel__title">Lorem Ipsum</span>
           <div class="panel__actions">
-            <button class="icon-btn" data-collapse="left" title="Collapse left" aria-label="Collapse left"><img class="diet-icon diet-icon--sm" src="/dieter/icons/chevron-left-16.svg" alt="" /></button>
+            <button class="icon-btn" data-collapse="left" title="Collapse left" aria-label="Collapse left"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/chevron-left-16.svg" alt="" /></button>
           </div>
         </div>
         <div class="panel__body">Lorem Ipsum</div>
@@ -32,16 +32,16 @@
 
       <section class="panel panel--center" aria-label="Center Panel">
         <div class="panel__header">
-          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/pencil-16.svg" alt="" /></span>
+          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/pencil-16.svg" alt="" /></span>
           <span class="panel__title">Lorem Ipsum</span>
           <div class="panel__controls">
             <div class="diet-segmented" role="tablist" aria-label="Theme" id="segTheme">
-              <button role="tab" aria-selected="true" data-theme="light" title="Light"><img class="diet-icon diet-icon--sm" src="/dieter/icons/sun-16.svg" alt="" /><span class="sr-only">Light</span></button>
-              <button role="tab" aria-selected="false" data-theme="dark" title="Dark"><img class="diet-icon diet-icon--sm" src="/dieter/icons/moon-16.svg" alt="" /><span class="sr-only">Dark</span></button>
+              <button role="tab" aria-selected="true" data-theme="light" title="Light"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/sun-16.svg" alt="" /><span class="sr-only">Light</span></button>
+              <button role="tab" aria-selected="false" data-theme="dark" title="Dark"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/moon-16.svg" alt="" /><span class="sr-only">Dark</span></button>
             </div>
             <div class="diet-segmented" role="tablist" aria-label="Viewport" id="segViewport">
-              <button role="tab" aria-selected="true" data-viewport="desktop" title="Desktop"><img class="diet-icon diet-icon--sm" src="/dieter/icons/desktop-16.svg" alt="" /><span class="sr-only">Desktop</span></button>
-              <button role="tab" aria-selected="false" data-viewport="mobile" title="Mobile"><img class="diet-icon diet-icon--sm" src="/dieter/icons/phone-16.svg" alt="" /><span class="sr-only">Mobile</span></button>
+              <button role="tab" aria-selected="true" data-viewport="desktop" title="Desktop"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/desktop-16.svg" alt="" /><span class="sr-only">Desktop</span></button>
+              <button role="tab" aria-selected="false" data-viewport="mobile" title="Mobile"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/phone-16.svg" alt="" /><span class="sr-only">Mobile</span></button>
             </div>
           </div>
         </div>
@@ -52,11 +52,11 @@
 
       <aside class="panel panel--right" aria-label="Right Panel">
         <div class="panel__header">
-          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/wrench-16.svg" alt="" /></span>
+          <span class="panel__icon"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/wrench-16.svg" alt="" /></span>
           <span class="panel__title">Lorem Ipsum</span>
           <div class="panel__actions">
-            <button class="icon-btn" id="copyBtn" title="Copy" aria-label="Copy"><img class="diet-icon diet-icon--sm" src="/dieter/icons/copy-16.svg" alt="" /></button>
-            <button class="icon-btn" data-collapse="right" title="Collapse right" aria-label="Collapse right"><img class="diet-icon diet-icon--sm" src="/dieter/icons/chevron-right-16.svg" alt="" /></button>
+            <button class="icon-btn" id="copyBtn" title="Copy" aria-label="Copy"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/copy-16.svg" alt="" /></button>
+            <button class="icon-btn" data-collapse="right" title="Collapse right" aria-label="Collapse right"><img class="diet-icon diet-icon--sm" src="/dieter/icons/svg/chevron-right-16.svg" alt="" /></button>
           </div>
         </div>
         <div class="panel__body">Lorem Ipsum</div>

--- a/tools/ci/assert-dieter-icon-present.cjs
+++ b/tools/ci/assert-dieter-icon-present.cjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const p = require('path');
+const target = p.join(__dirname, '..', '..', 'apps', 'app', 'public', 'dieter', 'icons', 'svg', 'chevron-right-16.svg');
+if (!fs.existsSync(target)) {
+  console.error(`[ERROR] Missing Dieter icon after build: ${target}`);
+  process.exit(1);
+}
+console.log('[OK] Dieter icon present:', target);


### PR DESCRIPTION
What changed\n- Update Studio public index to use canonical /dieter/icons/svg/<name>-<size>.svg paths.\n- Add App-level prebuild to build Dieter and copy assets to apps/app/public/dieter.\n- Add post-build guard to assert a representative icon exists.\n\nWhy\n- Production 404s occurred due to missing /svg/ segment in icon URLs.\n- Ensure Vercel App build always includes Dieter assets without symlinks.\n\nHow verified\n- Local build succeeded; copy-on-build populated public/dieter.\n- Guard reports [OK] Dieter icon present.\n