### PR TITLE
ci: guard against retired codename Oslo

### DIFF
--- a/.github/workflows/no-oslo.yml
+++ b/.github/workflows/no-oslo.yml
@@ -1,0 +1,13 @@
+name: guard-no-oslo
+on:
+  pull_request:
+    paths:
+      - '**/*'
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if retired codename Oslo appears
+        run: |
+          ! grep -R --line-number -I --exclude='scripts/scrub-oslo.sh' '\bOslo\b' . || (echo 'Retired codename Oslo found.' && exit 1)


### PR DESCRIPTION
Add CI job to fail PRs if Oslo is reintroduced. Ignores helper script.